### PR TITLE
build: switch to nodenext + skipLibCheck

### DIFF
--- a/src/playstationAccessory.ts
+++ b/src/playstationAccessory.ts
@@ -16,7 +16,7 @@ import { PlaystationPlatform } from './playstationPlatform.js';
 import { PLUGIN_NAME } from './settings.js';
 import { IDeviceConnection } from 'playactor/dist/connection/model.js';
 import AsyncLock from 'async-lock';
-import { ISocketConfig } from 'playactor/dist/socket/model';
+import type { ISocketConfig } from 'playactor/dist/socket/model.js';
 
 export class PlaystationAccessory {
   private readonly accessory: PlatformAccessory;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "lib": ["ES2022"],
-    "module": "ES2022",
+    "module": "nodenext",
     "target": "ES2022",
     "rootDir": "src",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "strict": true,
     "declaration": true,
     "outDir": "dist",
@@ -14,7 +14,8 @@
     "esModuleInterop": true,
     "noImplicitAny": false,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "include": [".eslintrc.json", "homebridge-ui", "src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
Mirror the same tsconfig hardening landed in `homebridge-philips-hue-sync-box` (#378, #379) preemptively, before homebridge 2.x's `@matter/*` transitive deps cause the same CI failure here.

## Changes
- `tsconfig.json`: `moduleResolution: "node"` → `"nodenext"`, `module: "ES2022"` → `"nodenext"`, add `skipLibCheck: true`.
- `src/playstationAccessory.ts`: `import { ISocketConfig } from 'playactor/dist/socket/model'` → `import type { ISocketConfig } from 'playactor/dist/socket/model.js'`. Type-only usage; classic `node` resolution silently accepted the missing extension because the import was erased at emit.

## Why
- Classic `moduleResolution: "node"` doesn't model Node's `package.json` `imports`/`exports`, so tsc and Node disagree about how to resolve deps. For an ESM project (`"type": "module"`) this mismatch is a footgun — see homebridge 2.x's `@matter/*` deps, whose declarations use subpath `imports` and DOM lib types that classic resolution can't follow.
- `nodenext` matches Node's runtime behavior. `module: "nodenext"` is the conventional pairing. `skipLibCheck` defends against unrelated upstream `.d.ts` rot (it's not a substitute for `nodenext` — they fix different problems).

## Verification
- `npm run build` (clean → compile) passes.
- `npm run lint` passes.

## Test plan
- [ ] CI passes on this PR
- [ ] Smoke test the plugin against a real PS4/PS5 + homebridge instance to confirm no runtime regression from `module: "nodenext"` (CJS/ESM interop semantics differ slightly from `module: "ES2022"`)