### PR TITLE
ci: advisory PR license check (Dependency-Track) + ship SBOMs with releases

### DIFF
--- a/.github/workflows/dt-sbom.yml
+++ b/.github/workflows/dt-sbom.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           set -euo pipefail
           npx --yes @cyclonedx/cyclonedx-npm@4.2.1 \
+            --ignore-npm-errors \
             --output-format JSON \
             --output-file sbom.cdx.json
 

--- a/.github/workflows/dt-sbom.yml
+++ b/.github/workflows/dt-sbom.yml
@@ -1,0 +1,104 @@
+---
+# Upload a CycloneDX SBOM of this repo's resolved npm dependencies to the
+# homelab Dependency-Track instance. This is the FOSSA replacement (fossa.yml
+# stays in place until DT is proven out across the OSS repos).
+#
+# Two jobs, because only one of them may touch the cluster:
+#   sbom   - hosted runner (UNTRUSTED): `npm ci` (which may run dependency
+#            lifecycle scripts) and the SBOM generator run here, never on the
+#            in-cluster runner. Emits sbom.cdx.json.
+#   upload - in-cluster arc-oss-homebridge-playstation runner: exchange this run's GitHub
+#            OIDC token for the Dependency-Track CI key via OpenBao
+#            (vault-action), then POST the SBOM. Project identity is taken from
+#            trusted GitHub context (github.repository / github.sha), NOT from
+#            anything the sbom job produced, so a compromised dependency can't
+#            inject values that get executed on the cluster runner. The runner is
+#            egress-locked to a few in-cluster services, so OpenBao and DT are
+#            addressed by their in-cluster Service DNS names, not the public
+#            gateway (the LE cert has no in-cluster SAN -> tlsSkipVerify; egress
+#            is identity-locked to the OpenBao pods, and pod-to-pod traffic is
+#            WireGuard-encrypted). The set is REPO-scoped (one arc-oss-<repo> set
+#            per OSS repo; a user account can't host shared runners). See
+#            github.com/jabrown93/homelab -> docs/dependency-track.md.
+#
+# push-to-main + manual only: never runs on pull_request, so fork PR code can't
+# reach the in-cluster runner. (PR license checks run via pr-license-check.yml,
+# which keeps fork PRs off the in-cluster runner.)
+name: Dependency-Track SBOM
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          set -euo pipefail
+          npx --yes @cyclonedx/cyclonedx-npm@4.2.1 \
+            --output-format JSON \
+            --output-file sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: sbom
+          if-no-files-found: error
+          path: sbom.cdx.json
+
+  upload:
+    needs: sbom
+    runs-on: arc-oss-homebridge-playstation
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: sbom
+
+      - name: Fetch DT API key from OpenBao
+        id: bao
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: https://openbao-active.openbao.svc.cluster.local:8200
+          tlsSkipVerify: true
+          method: jwt
+          path: github-actions
+          role: dt-sbom-upload
+          jwtGithubAudience: openbao
+          secrets: |
+            secret/data/dependency-track/ci-api-key apiKey | DT_API_KEY
+
+      - name: Upload SBOM to Dependency-Track
+        env:
+          DT_API_KEY: ${{ steps.bao.outputs.DT_API_KEY }}
+          PROJECT_NAME: github.com/${{ github.repository }}
+          PROJECT_VERSION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST http://dependency-track-api-server.dependency-track.svc.cluster.local:8080/api/v1/bom \
+            -H "X-Api-Key: ${DT_API_KEY}" \
+            -F "autoCreate=true" \
+            -F "projectName=${PROJECT_NAME}" \
+            -F "projectVersion=${PROJECT_VERSION}" \
+            -F "isLatest=true" \
+            -F "bom=@sbom.cdx.json"

--- a/.github/workflows/pr-license-check.yml
+++ b/.github/workflows/pr-license-check.yml
@@ -15,10 +15,11 @@
 #              upload the PR SBOM, poll until processing finishes, fetch the raw
 #              policy violations. Reaches OpenBao/DT by in-cluster Service DNS
 #              (egress-locked set). No jq on this image -> only raw JSON is
-#              emitted here; it is parsed on a hosted runner.
-#   comment  - hosted runner: render the LICENSE violations and post/update the
-#              advisory PR comment (needs a writable GITHUB_TOKEN, kept off the
-#              cluster runner).
+#              emitted here; it is parsed on a hosted runner. Fully non-fatal:
+#              it records the violation-fetch HTTP code and always exits 0.
+#   comment  - hosted runner: render the LICENSE violations (or an "unavailable"
+#              note) and post/update the advisory PR comment (needs a writable
+#              GITHUB_TOKEN, kept off the cluster runner).
 #
 # Same-repo PRs only: a fork PR gets no OIDC token and no writable token, and
 # must never reach the in-cluster runner. Fork PRs are skipped entirely.
@@ -54,6 +55,7 @@ jobs:
         run: |
           set -euo pipefail
           npx --yes @cyclonedx/cyclonedx-npm@4.2.1 \
+            --ignore-npm-errors \
             --output-format JSON \
             --output-file sbom.cdx.json
 
@@ -96,14 +98,19 @@ jobs:
           PROJECT_NAME: github.com/${{ github.repository }}
           PROJECT_VERSION: pr-${{ github.event.pull_request.number }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           DT=http://dependency-track-api-server.dependency-track.svc.cluster.local:8080
+          # Advisory: this step never fails the PR. Defaults stand in if any
+          # call falls through; the violation-fetch HTTP code is recorded for
+          # the comment job to interpret.
+          echo '[]' > violations.json
+          printf '000' > http_code.txt
           # Upload the PR SBOM. No isLatest -> the `main` version stays canonical.
-          resp=$(curl -fsS -H "X-Api-Key: ${DT_API_KEY}" -X POST "$DT/api/v1/bom" \
+          resp=$(curl -sS -H "X-Api-Key: ${DT_API_KEY}" -X POST "$DT/api/v1/bom" \
             -F autoCreate=true \
             -F "projectName=${PROJECT_NAME}" \
             -F "projectVersion=${PROJECT_VERSION}" \
-            -F "bom=@sbom.cdx.json")
+            -F "bom=@sbom.cdx.json") || { echo "SBOM upload failed"; exit 0; }
           token=$(printf '%s' "$resp" | sed -n 's/.*"token"[^"]*"\([^"]*\)".*/\1/p')
           echo "Upload token: ${token:-<none>}"
           # Poll until BOM ingestion finishes (cap ~5 min).
@@ -123,23 +130,26 @@ jobs:
             --data-urlencode "name=${PROJECT_NAME}" \
             --data-urlencode "version=${PROJECT_VERSION}" \
             | grep -oiE '"uuid"[[:space:]]*:[[:space:]]*"[0-9a-f-]{36}"' \
-            | grep -oiE '[0-9a-f-]{36}' | head -n1 || true)
+            | grep -oiE '[0-9a-f-]{36}' | head -n1)
           echo "Project UUID: ${uuid:-<none>}"
           # Fetch the raw policy violations (parsed on the hosted comment job).
           if [ -n "${uuid}" ]; then
-            curl -fsS -H "X-Api-Key: ${DT_API_KEY}" \
-              "$DT/api/v1/violation/project/${uuid}?suppressed=false&pageSize=1000" \
-              -o violations.json
-          else
-            echo '[]' > violations.json
+            code=$(curl -sS -H "X-Api-Key: ${DT_API_KEY}" -o violations.json -w '%{http_code}' \
+              "$DT/api/v1/violation/project/${uuid}?suppressed=false&pageSize=1000") || code=000
+            printf '%s' "${code}" > http_code.txt
+            echo "Violations HTTP: ${code}"
+            [ "${code}" = "200" ] || echo '[]' > violations.json
           fi
+          echo "done"
 
       - name: Upload violations artifact
         uses: actions/upload-artifact@v7.0.1
         with:
           name: violations
           if-no-files-found: error
-          path: violations.json
+          path: |
+            violations.json
+            http_code.txt
 
   comment:
     needs: evaluate
@@ -159,25 +169,31 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            let data = [];
-            try { data = JSON.parse(fs.readFileSync('violations.json', 'utf8')); } catch (e) {}
-            const all = Array.isArray(data) ? data : (data.violations || []);
-            const lic = all.filter(v => String(v.type || '').toUpperCase() === 'LICENSE');
             const marker = '<!-- dt-license-check -->';
             const dtUi = 'https://dependency-track.jaredbrown.io';
-            const fmt = (v) => {
-              const c = v.component || {};
-              const coord = c.purl || `${c.group ? c.group + ':' : ''}${c.name || '?'}@${c.version || '?'}`;
-              const pol = (v.policyCondition && v.policyCondition.policy && v.policyCondition.policy.name) || 'license policy';
-              const rl = c.resolvedLicense || {};
-              const lname = rl.name || rl.licenseId || c.license || '—';
-              return `| \`${coord}\` | ${lname} | ${pol} |`;
-            };
+            let code = '000';
+            try { code = fs.readFileSync('http_code.txt', 'utf8').trim(); } catch (e) {}
             let body;
-            if (lic.length === 0) {
-              body = `${marker}\n### ✅ Dependency-Track license check\n\nNo license policy violations for \`pr-${context.issue.number}\`.\n\n_Advisory only — reflects the GitOps DT license policies (FOSSA replacement). Vulnerabilities are not gated here. [Open in DT](${dtUi})._`;
+            if (code !== '200') {
+              body = `${marker}\n### ℹ️ Dependency-Track license check — evaluation unavailable\n\nDT returned HTTP \`${code}\` reading policy violations for \`pr-${context.issue.number}\`.\n\n- \`403\` → grant the **Automation** team the \`VIEW_POLICY_VIOLATION\` permission in DT (Administration → Access Management → Teams).\n- \`000\` → the SBOM upload or project lookup did not complete.\n\n_Advisory only — not blocking._`;
             } else {
-              body = `${marker}\n### ⚠️ Dependency-Track license check — ${lic.length} finding(s)\n\n| Component | License | Policy |\n|---|---|---|\n${lic.map(fmt).join('\n')}\n\n_Advisory only (non-blocking). Review at ${dtUi}. Source of truth: the GitOps DT license policies._`;
+              let data = [];
+              try { data = JSON.parse(fs.readFileSync('violations.json', 'utf8')); } catch (e) {}
+              const all = Array.isArray(data) ? data : (data.violations || []);
+              const lic = all.filter(v => String(v.type || '').toUpperCase() === 'LICENSE');
+              const fmt = (v) => {
+                const c = v.component || {};
+                const coord = c.purl || `${c.group ? c.group + ':' : ''}${c.name || '?'}@${c.version || '?'}`;
+                const pol = (v.policyCondition && v.policyCondition.policy && v.policyCondition.policy.name) || 'license policy';
+                const rl = c.resolvedLicense || {};
+                const lname = rl.name || rl.licenseId || c.license || '—';
+                return `| \`${coord}\` | ${lname} | ${pol} |`;
+              };
+              if (lic.length === 0) {
+                body = `${marker}\n### ✅ Dependency-Track license check\n\nNo license policy violations for \`pr-${context.issue.number}\`.\n\n_Advisory only — reflects the GitOps DT license policies (FOSSA replacement). Vulnerabilities are not gated here. [Open in DT](${dtUi})._`;
+              } else {
+                body = `${marker}\n### ⚠️ Dependency-Track license check — ${lic.length} finding(s)\n\n| Component | License | Policy |\n|---|---|---|\n${lic.map(fmt).join('\n')}\n\n_Advisory only (non-blocking). Review at ${dtUi}. Source of truth: the GitOps DT license policies._`;
+              }
             }
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;

--- a/.github/workflows/pr-license-check.yml
+++ b/.github/workflows/pr-license-check.yml
@@ -1,28 +1,18 @@
 ---
-# Advisory license check for pull requests, backed by Dependency-Track.
+# Producer half of the advisory PR license check (consumer: pr-license-comment.yml).
 #
-# Companion to dt-sbom.yml (which uploads the canonical `main` SBOM). This
-# uploads the PR's SBOM under a throwaway `pr-<number>` project version, lets
-# DT evaluate it against the GitOps license policies (the FOSSA replacement,
-# managed in jabrown93/homelab -> argocd/configs/dependency-track/policies.json),
-# and posts the LICENSE-type policy violations back as a NON-BLOCKING PR comment.
-# It never fails the PR -- the rules are visibility-only by design.
+# SECURITY BOUNDARY: a `pull_request` build runs the PR's OWN copy of this file
+# plus the PR's (untrusted) dependencies, so it holds NO secrets and never
+# reaches the cluster. It only builds the SBOM and hands it to the trusted
+# consumer as an artifact. The privileged upload-to-DT + PR comment runs in
+# pr-license-comment.yml, a `workflow_run` workflow that always executes the
+# main-branch definition, with the OpenBao role pinned to that file
+# @refs/heads/main. This mirrors argocd-diff.yaml in jabrown93/homelab and is the
+# GitHub-recommended pattern for giving secrets to PR-triggered automation
+# without exposing them to PR-controlled code.
 #
-# Three jobs, by trust boundary:
-#   sbom     - hosted runner (UNTRUSTED): `npm ci` + cyclonedx-npm. Build/dep
-#              lifecycle scripts run here, never on the in-cluster runner.
-#   evaluate - in-cluster arc-oss-homebridge-playstation runner: OIDC -> OpenBao -> DT CI key,
-#              upload the PR SBOM, poll until processing finishes, fetch the raw
-#              policy violations. Reaches OpenBao/DT by in-cluster Service DNS
-#              (egress-locked set). No jq on this image -> only raw JSON is
-#              emitted here; it is parsed on a hosted runner. Fully non-fatal:
-#              it records the violation-fetch HTTP code and always exits 0.
-#   comment  - hosted runner: render the LICENSE violations (or an "unavailable"
-#              note) and post/update the advisory PR comment (needs a writable
-#              GITHUB_TOKEN, kept off the cluster runner).
-#
-# Same-repo PRs only: a fork PR gets no OIDC token and no writable token, and
-# must never reach the in-cluster runner. Fork PRs are skipped entirely.
+# Public repo → hosted ubuntu-latest is free/unlimited and has no cluster reach,
+# which is exactly what we want for untrusted PR code.
 name: PR License Check (Dependency-Track)
 
 on:
@@ -34,10 +24,10 @@ permissions:
 
 jobs:
   sbom:
+    # Fork PRs can't produce a comment (the consumer is gated to same-repo runs),
+    # so don't bother building for them.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3
@@ -65,142 +55,3 @@ jobs:
           name: sbom
           if-no-files-found: error
           path: sbom.cdx.json
-
-  evaluate:
-    needs: sbom
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: arc-oss-homebridge-playstation
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Download SBOM artifact
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: sbom
-
-      - name: Fetch DT API key from OpenBao
-        id: bao
-        uses: hashicorp/vault-action@v4.0.0
-        with:
-          url: https://openbao-active.openbao.svc.cluster.local:8200
-          tlsSkipVerify: true
-          method: jwt
-          path: github-actions
-          role: dt-sbom-upload
-          jwtGithubAudience: openbao
-          secrets: |
-            secret/data/dependency-track/ci-api-key apiKey | DT_API_KEY
-
-      - name: Upload PR SBOM and collect license policy violations
-        env:
-          DT_API_KEY: ${{ steps.bao.outputs.DT_API_KEY }}
-          PROJECT_NAME: github.com/${{ github.repository }}
-          PROJECT_VERSION: pr-${{ github.event.pull_request.number }}
-        run: |
-          set -uo pipefail
-          DT=http://dependency-track-api-server.dependency-track.svc.cluster.local:8080
-          # Advisory: this step never fails the PR. Defaults stand in if any
-          # call falls through; the violation-fetch HTTP code is recorded for
-          # the comment job to interpret.
-          echo '[]' > violations.json
-          printf '000' > http_code.txt
-          # Upload the PR SBOM. No isLatest -> the `main` version stays canonical.
-          resp=$(curl -sS -H "X-Api-Key: ${DT_API_KEY}" -X POST "$DT/api/v1/bom" \
-            -F autoCreate=true \
-            -F "projectName=${PROJECT_NAME}" \
-            -F "projectVersion=${PROJECT_VERSION}" \
-            -F "bom=@sbom.cdx.json") || { echo "SBOM upload failed"; exit 0; }
-          token=$(printf '%s' "$resp" | sed -n 's/.*"token"[^"]*"\([^"]*\)".*/\1/p')
-          echo "Upload token: ${token:-<none>}"
-          # Poll until BOM ingestion finishes (cap ~5 min).
-          if [ -n "${token}" ]; then
-            for _ in $(seq 1 60); do
-              if curl -fsS -H "X-Api-Key: ${DT_API_KEY}" "$DT/api/v1/bom/token/${token}" \
-                   | grep -q '"processing"[[:space:]]*:[[:space:]]*false'; then
-                break
-              fi
-              sleep 5
-            done
-          fi
-          # Let policy evaluation settle after ingestion.
-          sleep 10
-          # Resolve the project UUID for this PR version.
-          uuid=$(curl -fsSG -H "X-Api-Key: ${DT_API_KEY}" "$DT/api/v1/project/lookup" \
-            --data-urlencode "name=${PROJECT_NAME}" \
-            --data-urlencode "version=${PROJECT_VERSION}" \
-            | grep -oiE '"uuid"[[:space:]]*:[[:space:]]*"[0-9a-f-]{36}"' \
-            | grep -oiE '[0-9a-f-]{36}' | head -n1)
-          echo "Project UUID: ${uuid:-<none>}"
-          # Fetch the raw policy violations (parsed on the hosted comment job).
-          if [ -n "${uuid}" ]; then
-            code=$(curl -sS -H "X-Api-Key: ${DT_API_KEY}" -o violations.json -w '%{http_code}' \
-              "$DT/api/v1/violation/project/${uuid}?suppressed=false&pageSize=1000") || code=000
-            printf '%s' "${code}" > http_code.txt
-            echo "Violations HTTP: ${code}"
-            [ "${code}" = "200" ] || echo '[]' > violations.json
-          fi
-          echo "done"
-
-      - name: Upload violations artifact
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: violations
-          if-no-files-found: error
-          path: |
-            violations.json
-            http_code.txt
-
-  comment:
-    needs: evaluate
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Download violations artifact
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: violations
-
-      - name: Render and post advisory license comment
-        uses: actions/github-script@v8.0.0
-        with:
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- dt-license-check -->';
-            const dtUi = 'https://dependency-track.jaredbrown.io';
-            let code = '000';
-            try { code = fs.readFileSync('http_code.txt', 'utf8').trim(); } catch (e) {}
-            let body;
-            if (code !== '200') {
-              body = `${marker}\n### ℹ️ Dependency-Track license check — evaluation unavailable\n\nDT returned HTTP \`${code}\` reading policy violations for \`pr-${context.issue.number}\`.\n\n- \`403\` → grant the **Automation** team the \`VIEW_POLICY_VIOLATION\` permission in DT (Administration → Access Management → Teams).\n- \`000\` → the SBOM upload or project lookup did not complete.\n\n_Advisory only — not blocking._`;
-            } else {
-              let data = [];
-              try { data = JSON.parse(fs.readFileSync('violations.json', 'utf8')); } catch (e) {}
-              const all = Array.isArray(data) ? data : (data.violations || []);
-              const lic = all.filter(v => String(v.type || '').toUpperCase() === 'LICENSE');
-              const fmt = (v) => {
-                const c = v.component || {};
-                const coord = c.purl || `${c.group ? c.group + ':' : ''}${c.name || '?'}@${c.version || '?'}`;
-                const pol = (v.policyCondition && v.policyCondition.policy && v.policyCondition.policy.name) || 'license policy';
-                const rl = c.resolvedLicense || {};
-                const lname = rl.name || rl.licenseId || c.license || '—';
-                return `| \`${coord}\` | ${lname} | ${pol} |`;
-              };
-              if (lic.length === 0) {
-                body = `${marker}\n### ✅ Dependency-Track license check\n\nNo license policy violations for \`pr-${context.issue.number}\`.\n\n_Advisory only — reflects the GitOps DT license policies (FOSSA replacement). Vulnerabilities are not gated here. [Open in DT](${dtUi})._`;
-              } else {
-                body = `${marker}\n### ⚠️ Dependency-Track license check — ${lic.length} finding(s)\n\n| Component | License | Policy |\n|---|---|---|\n${lic.map(fmt).join('\n')}\n\n_Advisory only (non-blocking). Review at ${dtUi}. Source of truth: the GitOps DT license policies._`;
-              }
-            }
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }

--- a/.github/workflows/pr-license-check.yml
+++ b/.github/workflows/pr-license-check.yml
@@ -1,0 +1,190 @@
+---
+# Advisory license check for pull requests, backed by Dependency-Track.
+#
+# Companion to dt-sbom.yml (which uploads the canonical `main` SBOM). This
+# uploads the PR's SBOM under a throwaway `pr-<number>` project version, lets
+# DT evaluate it against the GitOps license policies (the FOSSA replacement,
+# managed in jabrown93/homelab -> argocd/configs/dependency-track/policies.json),
+# and posts the LICENSE-type policy violations back as a NON-BLOCKING PR comment.
+# It never fails the PR -- the rules are visibility-only by design.
+#
+# Three jobs, by trust boundary:
+#   sbom     - hosted runner (UNTRUSTED): `npm ci` + cyclonedx-npm. Build/dep
+#              lifecycle scripts run here, never on the in-cluster runner.
+#   evaluate - in-cluster arc-oss-homebridge-playstation runner: OIDC -> OpenBao -> DT CI key,
+#              upload the PR SBOM, poll until processing finishes, fetch the raw
+#              policy violations. Reaches OpenBao/DT by in-cluster Service DNS
+#              (egress-locked set). No jq on this image -> only raw JSON is
+#              emitted here; it is parsed on a hosted runner.
+#   comment  - hosted runner: render the LICENSE violations and post/update the
+#              advisory PR comment (needs a writable GITHUB_TOKEN, kept off the
+#              cluster runner).
+#
+# Same-repo PRs only: a fork PR gets no OIDC token and no writable token, and
+# must never reach the in-cluster runner. Fork PRs are skipped entirely.
+name: PR License Check (Dependency-Track)
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          set -euo pipefail
+          npx --yes @cyclonedx/cyclonedx-npm@4.2.1 \
+            --output-format JSON \
+            --output-file sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: sbom
+          if-no-files-found: error
+          path: sbom.cdx.json
+
+  evaluate:
+    needs: sbom
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: arc-oss-homebridge-playstation
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: sbom
+
+      - name: Fetch DT API key from OpenBao
+        id: bao
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: https://openbao-active.openbao.svc.cluster.local:8200
+          tlsSkipVerify: true
+          method: jwt
+          path: github-actions
+          role: dt-sbom-upload
+          jwtGithubAudience: openbao
+          secrets: |
+            secret/data/dependency-track/ci-api-key apiKey | DT_API_KEY
+
+      - name: Upload PR SBOM and collect license policy violations
+        env:
+          DT_API_KEY: ${{ steps.bao.outputs.DT_API_KEY }}
+          PROJECT_NAME: github.com/${{ github.repository }}
+          PROJECT_VERSION: pr-${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          DT=http://dependency-track-api-server.dependency-track.svc.cluster.local:8080
+          # Upload the PR SBOM. No isLatest -> the `main` version stays canonical.
+          resp=$(curl -fsS -H "X-Api-Key: ${DT_API_KEY}" -X POST "$DT/api/v1/bom" \
+            -F autoCreate=true \
+            -F "projectName=${PROJECT_NAME}" \
+            -F "projectVersion=${PROJECT_VERSION}" \
+            -F "bom=@sbom.cdx.json")
+          token=$(printf '%s' "$resp" | sed -n 's/.*"token"[^"]*"\([^"]*\)".*/\1/p')
+          echo "Upload token: ${token:-<none>}"
+          # Poll until BOM ingestion finishes (cap ~5 min).
+          if [ -n "${token}" ]; then
+            for _ in $(seq 1 60); do
+              if curl -fsS -H "X-Api-Key: ${DT_API_KEY}" "$DT/api/v1/bom/token/${token}" \
+                   | grep -q '"processing"[[:space:]]*:[[:space:]]*false'; then
+                break
+              fi
+              sleep 5
+            done
+          fi
+          # Let policy evaluation settle after ingestion.
+          sleep 10
+          # Resolve the project UUID for this PR version.
+          uuid=$(curl -fsSG -H "X-Api-Key: ${DT_API_KEY}" "$DT/api/v1/project/lookup" \
+            --data-urlencode "name=${PROJECT_NAME}" \
+            --data-urlencode "version=${PROJECT_VERSION}" \
+            | grep -oiE '"uuid"[[:space:]]*:[[:space:]]*"[0-9a-f-]{36}"' \
+            | grep -oiE '[0-9a-f-]{36}' | head -n1 || true)
+          echo "Project UUID: ${uuid:-<none>}"
+          # Fetch the raw policy violations (parsed on the hosted comment job).
+          if [ -n "${uuid}" ]; then
+            curl -fsS -H "X-Api-Key: ${DT_API_KEY}" \
+              "$DT/api/v1/violation/project/${uuid}?suppressed=false&pageSize=1000" \
+              -o violations.json
+          else
+            echo '[]' > violations.json
+          fi
+
+      - name: Upload violations artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: violations
+          if-no-files-found: error
+          path: violations.json
+
+  comment:
+    needs: evaluate
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download violations artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: violations
+
+      - name: Render and post advisory license comment
+        uses: actions/github-script@v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            let data = [];
+            try { data = JSON.parse(fs.readFileSync('violations.json', 'utf8')); } catch (e) {}
+            const all = Array.isArray(data) ? data : (data.violations || []);
+            const lic = all.filter(v => String(v.type || '').toUpperCase() === 'LICENSE');
+            const marker = '<!-- dt-license-check -->';
+            const dtUi = 'https://dependency-track.jaredbrown.io';
+            const fmt = (v) => {
+              const c = v.component || {};
+              const coord = c.purl || `${c.group ? c.group + ':' : ''}${c.name || '?'}@${c.version || '?'}`;
+              const pol = (v.policyCondition && v.policyCondition.policy && v.policyCondition.policy.name) || 'license policy';
+              const rl = c.resolvedLicense || {};
+              const lname = rl.name || rl.licenseId || c.license || '—';
+              return `| \`${coord}\` | ${lname} | ${pol} |`;
+            };
+            let body;
+            if (lic.length === 0) {
+              body = `${marker}\n### ✅ Dependency-Track license check\n\nNo license policy violations for \`pr-${context.issue.number}\`.\n\n_Advisory only — reflects the GitOps DT license policies (FOSSA replacement). Vulnerabilities are not gated here. [Open in DT](${dtUi})._`;
+            } else {
+              body = `${marker}\n### ⚠️ Dependency-Track license check — ${lic.length} finding(s)\n\n| Component | License | Policy |\n|---|---|---|\n${lic.map(fmt).join('\n')}\n\n_Advisory only (non-blocking). Review at ${dtUi}. Source of truth: the GitOps DT license policies._`;
+            }
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/pr-license-comment.yml
+++ b/.github/workflows/pr-license-comment.yml
@@ -1,0 +1,178 @@
+---
+# Consumer half of the advisory PR license check (producer: pr-license-check.yml).
+#
+# `workflow_run` always runs THIS file from the default branch (main), never the
+# PR's version -- that is the trust boundary. The untrusted PR-context producer
+# holds no secrets and only builds the SBOM; the Dependency-Track CI key is
+# exposed only here, to trusted main-pinned code. The OpenBao role `dt-pr-license`
+# is bound to this file @refs/heads/main (job_workflow_ref), so a same-repo PR
+# that rewrites the producer cannot mint the key. Mirrors argocd-diff-comment.yaml
+# in jabrown93/homelab. Advisory only: it never fails anything, it posts a comment.
+#
+# Same-repo PRs only: `workflow_run.pull_requests` is populated for branches in
+# this repo and empty for forks (which also get no token). See
+# jabrown93/homelab -> docs/dependency-track.md.
+#
+# NOTE: workflow_run uses the main-branch copy of this file, so the PR that first
+# adds it gets no comment; it activates for PRs opened after this merges to main.
+name: PR License Comment (Dependency-Track)
+
+on:
+  workflow_run:
+    workflows:
+      - PR License Check (Dependency-Track)
+    types:
+      - completed
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: pr-license-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    name: evaluate
+    runs-on: arc-oss-homebridge-playstation
+    # Only same-repo pull_request producer runs that succeeded. Forks have no
+    # token access and an empty pull_requests array.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.pull_requests[0] != null
+    steps:
+      - name: Resolve PR number from the trigger event
+        id: meta
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+          [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]] || { echo "bad PR number"; exit 1; }
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Download SBOM from the producer run
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: sbom
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch DT API key from OpenBao
+        id: bao
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: https://openbao-active.openbao.svc.cluster.local:8200
+          tlsSkipVerify: true
+          method: jwt
+          path: github-actions
+          role: dt-pr-license
+          jwtGithubAudience: openbao
+          secrets: |
+            secret/data/dependency-track/ci-api-key apiKey | DT_API_KEY
+
+      - name: Upload PR SBOM and collect license policy violations
+        env:
+          DT_API_KEY: ${{ steps.bao.outputs.DT_API_KEY }}
+          PROJECT_NAME: github.com/${{ github.repository }}
+          PROJECT_VERSION: pr-${{ steps.meta.outputs.pr_number }}
+        run: |
+          set -uo pipefail
+          DT=http://dependency-track-api-server.dependency-track.svc.cluster.local:8080
+          # Advisory: never fail. Emit a status + violations.json for the renderer.
+          echo '[]' > violations.json
+          echo 'unavailable:000' > status.txt
+          # Upload the PR SBOM (no isLatest -> the main version stays canonical).
+          # Use -f so an HTTP error is caught here rather than silently falling
+          # through to a STALE pre-existing pr-<n> project on lookup.
+          resp=$(curl -fsS -H "X-Api-Key: ${DT_API_KEY}" -X POST "$DT/api/v1/bom" \
+            -F autoCreate=true \
+            -F "projectName=${PROJECT_NAME}" \
+            -F "projectVersion=${PROJECT_VERSION}" \
+            -F "bom=@sbom.cdx.json") || { echo 'upload-failed' > status.txt; echo "upload failed"; exit 0; }
+          token=$(printf '%s' "$resp" | sed -n 's/.*"token"[^"]*"\([^"]*\)".*/\1/p')
+          if [ -z "${token}" ]; then echo 'upload-failed' > status.txt; echo "no token"; exit 0; fi
+          # Poll until BOM ingestion finishes (cap ~5 min); track whether it did.
+          processed=false
+          for _ in $(seq 1 60); do
+            if curl -fsS -H "X-Api-Key: ${DT_API_KEY}" "$DT/api/v1/bom/token/${token}" \
+                 | grep -q '"processing"[[:space:]]*:[[:space:]]*false'; then
+              processed=true
+              break
+            fi
+            sleep 5
+          done
+          if [ "${processed}" != "true" ]; then echo 'processing' > status.txt; echo "still processing after cap"; exit 0; fi
+          sleep 5  # brief settle for policy evaluation after ingestion
+          # Resolve the project UUID for this PR version (needs VIEW_PORTFOLIO).
+          uuid=$(curl -fsSG -H "X-Api-Key: ${DT_API_KEY}" "$DT/api/v1/project/lookup" \
+            --data-urlencode "name=${PROJECT_NAME}" \
+            --data-urlencode "version=${PROJECT_VERSION}" \
+            | grep -oiE '"uuid"[[:space:]]*:[[:space:]]*"[0-9a-f-]{36}"' \
+            | grep -oiE '[0-9a-f-]{36}' | head -n1)
+          if [ -z "${uuid}" ]; then echo 'no-project' > status.txt; echo "no uuid"; exit 0; fi
+          # Fetch policy violations (needs VIEW_POLICY_VIOLATION).
+          code=$(curl -sS -H "X-Api-Key: ${DT_API_KEY}" -o violations.json -w '%{http_code}' \
+            "$DT/api/v1/violation/project/${uuid}?suppressed=false&pageSize=1000") || code=000
+          echo "Violations HTTP: ${code}"
+          if [ "${code}" = "200" ]; then
+            echo 'ok' > status.txt
+          else
+            echo "unavailable:${code}" > status.txt
+            echo '[]' > violations.json
+          fi
+          echo "done"
+
+      - name: Render and post advisory license comment
+        uses: actions/github-script@v8.0.0
+        env:
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- dt-license-check -->';
+            const dtUi = 'https://dependency-track.jaredbrown.io';
+            const prNum = Number(process.env.PR_NUMBER);
+            let status = 'unavailable:000';
+            try { status = fs.readFileSync('status.txt', 'utf8').trim(); } catch (e) {}
+            const esc = (s) => String(s).replace(/[|`\\]/g, '\\$&').replace(/\r?\n/g, ' ');
+            let body;
+            if (status === 'ok') {
+              let data = [];
+              try { data = JSON.parse(fs.readFileSync('violations.json', 'utf8')); } catch (e) {}
+              const all = Array.isArray(data) ? data : (data.violations || []);
+              const lic = all.filter(v => String(v.type || '').toUpperCase() === 'LICENSE');
+              if (lic.length === 0) {
+                body = `${marker}\n### ✅ Dependency-Track license check\n\nNo license policy violations for \`pr-${prNum}\`.\n\n_Advisory only — reflects the GitOps DT license policies (FOSSA replacement). Vulnerabilities are not gated here. [Open in DT](${dtUi})._`;
+              } else {
+                const rows = lic.map((v) => {
+                  const c = v.component || {};
+                  const coord = c.purl || `${c.group ? c.group + ':' : ''}${c.name || '?'}@${c.version || '?'}`;
+                  const pol = (v.policyCondition && v.policyCondition.policy && v.policyCondition.policy.name) || 'license policy';
+                  const rl = c.resolvedLicense || {};
+                  const lname = rl.name || rl.licenseId || c.license || '—';
+                  return `| \`${esc(coord)}\` | ${esc(lname)} | ${esc(pol)} |`;
+                }).join('\n');
+                body = `${marker}\n### ⚠️ Dependency-Track license check — ${lic.length} finding(s)\n\n| Component | License | Policy |\n|---|---|---|\n${rows}\n\n_Advisory only (non-blocking). Review at ${dtUi}. Source of truth: the GitOps DT license policies._`;
+              }
+            } else if (status.startsWith('unavailable:')) {
+              const code = status.slice('unavailable:'.length);
+              body = `${marker}\n### ℹ️ Dependency-Track license check — evaluation unavailable\n\nDT returned HTTP \`${code}\` reading policy violations for \`pr-${prNum}\`.\n\n- \`403\` → grant the **Automation** team \`VIEW_POLICY_VIOLATION\` in DT (Administration → Access Management → Teams).\n\n_Advisory only — not blocking._`;
+            } else if (status === 'processing') {
+              body = `${marker}\n### ⏳ Dependency-Track license check — inconclusive\n\nDT was still processing the SBOM for \`pr-${prNum}\` after the poll window; no verdict this run. Re-runs on the next push.\n\n_Advisory only — not blocking._`;
+            } else if (status === 'upload-failed') {
+              body = `${marker}\n### ℹ️ Dependency-Track license check — SBOM upload failed\n\nThe SBOM upload to DT did not succeed for \`pr-${prNum}\` (DT unreachable or rejected the BOM).\n\n_Advisory only — not blocking._`;
+            } else {
+              body = `${marker}\n### ℹ️ Dependency-Track license check — inconclusive\n\nCould not evaluate \`pr-${prNum}\` (project lookup returned no result).\n\n_Advisory only — not blocking._`;
+            }
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: prNum });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNum, body });
+            }

--- a/.github/workflows/pr-license-comment.yml
+++ b/.github/workflows/pr-license-comment.yml
@@ -25,12 +25,16 @@ on:
       - completed
 
 permissions:
+  actions: read           # download-artifact run-id mode (cross-run) needs this
   contents: read
   id-token: write
   pull-requests: write
 
 concurrency:
-  group: pr-license-${{ github.event.workflow_run.head_branch }}
+  # Suffix by conclusion so a failed/skipped producer's (no-op) consumer run can't
+  # cancel an in-flight successful evaluation; successful runs still supersede each
+  # other (newest wins).
+  group: pr-license-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.conclusion }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
       - run: npm clean-install
+      - name: Generate CycloneDX SBOM (attached to the GitHub release)
+        run: |
+          set -euo pipefail
+          npx --yes @cyclonedx/cyclonedx-npm@4.2.1 \
+            --ignore-npm-errors \
+            --output-format JSON \
+            --output-file sbom.cdx.json
       - run: npm audit signatures
       - name: Configure atomic git pushes
         run: git config --global push.atomic true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
       - run: npm clean-install
-      - name: Generate CycloneDX SBOM (attached to the GitHub release)
-        run: |
-          set -euo pipefail
-          npx --yes @cyclonedx/cyclonedx-npm@4.2.1 \
-            --ignore-npm-errors \
-            --output-format JSON \
-            --output-file sbom.cdx.json
       - run: npm audit signatures
       - name: Configure atomic git pushes
         run: git config --global push.atomic true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -50,7 +50,14 @@
         "tarballDir": "dist"
       }
     ],
-    ["@semantic-release/github"],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          { "path": "sbom.cdx.json", "label": "CycloneDX SBOM (sbom.cdx.json)" }
+        ]
+      }
+    ],
     [
       "@semantic-release/git",
       {

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -51,6 +51,12 @@
       }
     ],
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "npx --yes @cyclonedx/cyclonedx-npm@4.2.1 --ignore-npm-errors --output-format JSON --output-file sbom.cdx.json"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "assets": [


### PR DESCRIPTION
## Advisory PR license check (Dependency-Track) — workflow_run split + release SBOMs

### PR license check (the FOSSA-on-PRs replacement)
Two workflows, split by trust boundary (same pattern as homelab `argocd-diff`):
- **`pr-license-check.yml`** — producer, `pull_request`, hosted `ubuntu-latest`, **no secrets**. Builds the CycloneDX SBOM, uploads it as an artifact.
- **`pr-license-comment.yml`** — consumer, `workflow_run` from **main**, in-cluster `arc-oss-<repo>`. Downloads the SBOM, mints the DT key via the `job_workflow_ref`-pinned **`dt-pr-license`** OpenBao role, uploads a throwaway `pr-<n>` DT project version, and posts an **advisory, non-blocking** license-violations comment.

Closes the trust boundary the reviewers flagged: a same-repo PR can no longer mint the DT key (the role is pinned to `pr-license-comment.yml@refs/heads/main`, and the privileged half never runs PR-authored YAML). Also adds per-PR concurrency, an upload `-f` guard (no stale-project reads), poll-completion tracking, and markdown escaping.

### Ship the SBOM with releases
`release.yml` generates `sbom.cdx.json` and `@semantic-release/github` attaches it as a **GitHub Release asset** (npm has no native SBOM storage; npm provenance is unchanged). Fail-safe: the SBOM is generated **before** `semantic-release`, so a failure aborts the release before publishing rather than half-releasing.


> Also adds the base `dt-sbom.yml` (push-to-main SBOM upload) — this repo had not been migrated off FOSSA yet.

### ⚠️ Activation order (consumer runs from main)
`workflow_run` uses the **main-branch** consumer, so **this PR itself gets no license comment** — the check activates for PRs opened after this merges. Before merging the OSS PRs:
1. Merge homelab **#1185** (adds the `dt-pr-license` role) and let ArgoCD `sync openbao`.
2. Grant the DT `Automation` team `VIEW_POLICY_VIOLATION`.

_(The earlier `403` advisory comment on this PR is from the prior single-workflow version and is now stale.)_
