### PR TITLE
feat(engines): support Node 22 LTS alongside Node 24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 20.x
           - 22.x
           - 24.x
 

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "engines": {
     "homebridge": "^1.8.0 || ^2.0.0-beta.0",
-    "node": "^24.0.0"
+    "node": "^22.0.0 || ^24.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
Standardize on the currently supported Node LTS lines — Node 22 (Jod) and Node 24 (Krypton).

## Changes
- `engines.node`: `^24.0.0` → `^22.0.0 || ^24.0.0` (re-add Node 22 LTS)
- CI build matrix (`build.yaml`): `[20.x, 22.x, 24.x]` → `[22.x, 24.x]` (drop EOL Node 20)

## Release impact
Broadening the supported Node range is additive → semantic-release **minor** bump.
