### PR TITLE
fix(engines): tighten Node floors to 22.12.0 and first LTS 24.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "engines": {
     "homebridge": "^1.8.0 || ^2.0.0-beta.0",
-    "node": "^22.0.0 || ^24.0.0"
+    "node": "^22.12.0 || ^24.11.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
Follow-up to #195. Tighten the Node engine floors that PR set to the loose `^22.0.0 || ^24.0.0`.

## Changes
- `engines.node`: `^22.0.0 || ^24.0.0` → `^22.12.0 || ^24.11.0`
  - **24.11.0** is the first Krypton LTS release (per nodejs.org).
  - **22.12.0** for the 22 line — first Jod LTS is 22.11.0, raised one patch to satisfy the dev toolchain (`commitlint` requires `>=22.12.0`).

## Why
`^22.0.0 || ^24.0.0` advertised support for pre-LTS Node patch levels the dependencies don't actually support. `engine-strict` is off so this only produced install warnings, but the metadata was misleading. (Codex flagged the same on the sibling smartrent PR.) Matches the `homebridge-philips-hue-sync-box` (`^24.11.0`) and `homebridge-dyson-pure-cool` (`^22.12.0`) floors.

## Release impact
`#195` is merged but its release (1.6.0) has not published yet, so this lands in the same upcoming minor — no separate breaking change.
