### PR TITLE
fix(release): restore changelog bodies by pinning conventionalcommits to v9

### DIFF
--- a/.github/workflows/pr-license-comment.yml
+++ b/.github/workflows/pr-license-comment.yml
@@ -25,7 +25,7 @@ on:
       - completed
 
 permissions:
-  actions: read           # download-artifact run-id mode (cross-run) needs this
+  actions: read # download-artifact run-id mode (cross-run) needs this
   contents: read
   id-token: write
   pull-requests: write

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 dist
 package-lock.json
 CHANGELOG.md
+sbom.cdx.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@types/node": "24.13.3",
         "@typescript-eslint/eslint-plugin": "8.64.0",
         "@typescript-eslint/parser": "8.64.0",
-        "conventional-changelog-conventionalcommits": "10.2.1",
+        "conventional-changelog-conventionalcommits": "9.3.1",
         "cross-env": "10.1.0",
         "eslint": "10.7.0",
         "eslint-plugin-ava": "17.0.1",
@@ -188,6 +188,19 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -4472,16 +4485,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
-      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@types/node": "24.13.3",
     "@typescript-eslint/eslint-plugin": "8.64.0",
     "@typescript-eslint/parser": "8.64.0",
-    "conventional-changelog-conventionalcommits": "10.2.1",
+    "conventional-changelog-conventionalcommits": "9.3.1",
     "cross-env": "10.1.0",
     "eslint": "10.7.0",
     "eslint-plugin-ava": "17.0.1",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>jabrown93/.github//renovate-config.json"]
+  "extends": ["github>jabrown93/.github//renovate-config.json"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["conventional-changelog-conventionalcommits"],
+      "allowedVersions": "<10.0.0",
+      "description": "Pinned to v9: v10 builds writerOpts from @conventional-changelog/template JS functions that require conventional-changelog-writer v9, but @semantic-release/release-notes-generator pins conventional-changelog-writer ^8 and silently ignores them, producing heading-only CHANGELOG entries with no commit bodies. Unpin once release-notes-generator supports writer v9."
+    }
+  ]
 }


### PR DESCRIPTION
## Problem (latent — will bite on the next release)

`conventional-changelog-conventionalcommits` **v10** builds its `writerOpts` from `@conventional-changelog/template` JS functions, which require `conventional-changelog-writer` **v9**. `@semantic-release/release-notes-generator@14.1.1` (latest) pins `conventional-changelog-writer@^8`, which cannot consume them — it silently discards the preset's `template`/`transform`, falls back to its own default header template, and drops every commit.

The result is a heading-only CHANGELOG entry with no commit bodies. Nothing errors.

This repo has **not released since the v10 bump**, so no stub has shipped yet — but the next release would produce one.

Confirmed already broken in sibling repos with the identical dependency combination:
- `homebridge-philips-hue-sync-box` — `3.0.2` through `3.0.5` all stubs
- `homebridge-onkyo` — `1.5.2` stub

## Changes

- Pin `conventional-changelog-conventionalcommits` to `9.3.1`. `@commitlint/config-conventional` requires `^10.0.0` and resolves its own nested v10; it only uses the parser, so it is unaffected.
- Renovate rule blocking v10 until `release-notes-generator` supports writer v9. Renovate introduced this, so without the rule it regresses silently.
- Ignore the generated `sbom.cdx.json` in `.prettierignore` — `.releaserc.json` generates it during `prepare`, and `prepublishOnly` runs `prettier --check .`, so the generated SBOM can fail the publish.
- Repo-wide `prettier --write .`. `.github/workflows/pr-license-comment.yml` was **already unformatted** and would have failed that same check. All changes are formatting-only.

There is no upstream fix to wait for — `release-notes-generator@14.1.1` is the latest and still pins writer `^8`.