### PR TITLE
feat(engines): standardize Node engines, CI triggers, and deprecate Homebridge 1.x

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,12 +10,6 @@ jobs:
   build:
     # node-build is now a composite action, so the caller owns the matrix and
     # runs-on (a composite action cannot declare either).
-    # push and pull_request both fire for a same-repo branch; the push run
-    # already covers the commit (and Renovate branch-automerge has no PR), so
-    # skip the duplicate PR run. Fork PRs don't fire push here, so still run.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   - push
   - pull_request
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,14 +3,23 @@ name: Build and Lint
 on:
   - push
   - pull_request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     # node-build is now a composite action, so the caller owns the matrix and
     # runs-on (a composite action cannot declare either).
+    # push and pull_request both fire for a same-repo branch; the push run
+    # already covers the commit (and Renovate branch-automerge has no PR), so
+    # skip the duplicate PR run. Fork PRs don't fire push here, so still run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22.x', '24.x']
+        node-version: ['22.x', '24.x', '26.x']
     runs-on: ubuntu-latest
     steps:
       - uses: jabrown93/ci/actions/node-build@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # node-build-v1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
       - beta
+      - alpha
+      - next
   # Weekly roll-up of the fix(deps) commits that .releaserc.js suppresses on
   # push, promoted into a single patch release. GitHub only fires schedule
   # from the default branch, so this sweeps main only; use the manual trigger

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Homebridge dynamic platform plugin that exposes PS4/PS5 consoles to HomeKit as T
 
 Heavy lifting (discovery, wake, standby, title control) is delegated to [`playactor`](https://github.com/dhleong/playactor). This plugin is a thin Homebridge adapter on top of it. Before adding logic that talks to a PlayStation, check whether playactor already exposes the primitive.
 
-Node `^24.0.0` (see `.nvmrc` → `24`), ESM (`"type": "module"`) — local imports must include the `.js` extension even in `.ts` source. Homebridge engines: `^1.8.0 || ^2.0.0-beta.0`.
+Node `^22.12.0 || ^24.11.0 || ^26.0.0` (`.nvmrc` pins the local dev default to `24`), ESM (`"type": "module"`) — local imports must include the `.js` extension even in `.ts` source. Homebridge engines: `^1.8.0 || ^2.0.0-beta.0` (1.x is deprecated and will be dropped in a future major release).
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ## WARNING: This plugin is not actively maintained except for automated dependency updates. Issues/bugs are unlikely to be addressed. Use at your own risk
 
+> Homebridge 1.x support is deprecated and will be removed in a future major release — please upgrade to Homebridge 2.x. Requires Node.js `^22.12.0`, `^24.11.0`, or `^26.0.0`.
+
 ### Playstation integration for Homebridge / HOOBS.
 
 _Hey Siri, turn on Playstation_ finally possible!

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "engines": {
     "homebridge": "^1.8.0 || ^2.0.0-beta.0",
-    "node": "^22.12.0 || ^24.11.0"
+    "node": "^22.12.0 || ^24.11.0 || ^26.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint:fix": "eslint src/**.ts --fix",
     "clean": "rimraf ./dist",
     "compile": "tsc",
-    "build": "rimraf ./dist && npm-run-all clean compile",
+    "build": "npm-run-all clean compile",
     "watch": "npm run setup-config && npm run build && npm link && nodemon",
     "semantic-release": "cross-env semantic-release --no-ci",
     "release": "npm-run-all build semantic-release",

--- a/src/playstationPlatform.ts
+++ b/src/playstationPlatform.ts
@@ -27,6 +27,12 @@ export class PlaystationPlatform implements DynamicPlatformPlugin {
     public readonly config: PlaystationPlatformConfig,
     public readonly api: API
   ) {
+    if (this.api.serverVersion.startsWith('1.')) {
+      this.log.warn(
+        'This plugin will drop support for Homebridge 1.x in a future release. Please upgrade to Homebridge 2.x.'
+      );
+    }
+
     this.Service = this.api.hap.Service;
     this.Characteristic = this.api.hap.Characteristic;
     this.log.debug('Config', JSON.stringify(config));


### PR DESCRIPTION
## Summary
- Add Node.js 26 to the supported engines range alongside 22/24
- Deprecate Homebridge 1.x: runtime warning + README/AGENTS.md notes (engines.homebridge unchanged for now — this only announces the future removal)
- Fix redundant double-clean in the build script
- CI: stop double-running Build and Lint for push+PR on the same commit; add node 26 to the CI matrix
- CI: release workflow was missing `alpha`/`next` in its push trigger even though .releaserc.json already treats them as release branches — releases to those branches were silently never firing

## Test plan
- [x] `npm ci && npm run build && npm run typecheck && npm run lint && npm test` all pass in the worktree