### PR TITLE
ci: migrate shared CI to jabrown93/ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,14 @@ on:
   - pull_request
 jobs:
   build:
-    uses: jabrown93/.github/.github/workflows/node-build.yml@71c3af9fc09ce87b086cc058773380acaf2b1299 # v1.2.0
-    with:
-      node-versions: '["22.x", "24.x"]'
+    # node-build is now a composite action, so the caller owns the matrix and
+    # runs-on (a composite action cannot declare either).
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22.x', '24.x']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jabrown93/ci/actions/node-build@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # node-build-v1.0.0
+        with:
+          node-version: ${{ matrix.node-version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,9 +9,14 @@ on:
     - cron: '25 22 * * 5'
 jobs:
   analyze:
-    uses: jabrown93/.github/.github/workflows/codeql.yml@71c3af9fc09ce87b086cc058773380acaf2b1299 # v1.2.0
+    # codeql is now a composite action, so the caller owns runs-on and MUST
+    # grant the permissions CodeQL needs. Language defaults to
+    # javascript-typescript / build-mode none, which is correct for this repo.
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       packages: read
       actions: read
       contents: read
+    steps:
+      - uses: jabrown93/ci/actions/codeql@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # codeql-v1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   release:
-    uses: jabrown93/.github/.github/workflows/npm-release.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
+    uses: jabrown93/ci/.github/workflows/npm-release.yml@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # workflows-v1.0.0
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,8 +5,12 @@ on:
     - cron: '30 1 * * *'
 jobs:
   stale:
-    uses: jabrown93/.github/.github/workflows/stale.yml@71c3af9fc09ce87b086cc058773380acaf2b1299 # v1.2.0
+    # stale is now a composite action, so the caller owns runs-on and MUST grant
+    # the permissions actions/stale needs. The schedule trigger stays here.
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       issues: write
       pull-requests: write
+    steps:
+      - uses: jabrown93/ci/actions/stale@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # stale-v1.0.0

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -19,67 +19,76 @@
 // `${...}` placeholders are expanded by semantic-release, not by JS -- keep
 // them inside double-quoted strings so JS does not interpolate them.
 
-const releaseDeps = process.env.RELEASE_DEPS === "true";
+const releaseDeps = process.env.RELEASE_DEPS === 'true';
 
 const depReleaseRules = [
   // Required: commit-analyzer evaluates every matching custom rule and keeps
   // the highest release type, so without this a breaking fix(deps)! would
   // match ONLY the suppression rule below and never release. Listed first so
   // the analyzer short-circuits on major.
-  { type: "fix", scope: "deps", breaking: true, release: "major" },
+  { type: 'fix', scope: 'deps', breaking: true, release: 'major' },
   releaseDeps
-    ? { type: "fix", scope: "deps", release: "patch" }
-    : { type: "fix", scope: "deps", release: false },
+    ? { type: 'fix', scope: 'deps', release: 'patch' }
+    : { type: 'fix', scope: 'deps', release: false },
 ];
 
-const noteKeywords = ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"];
+const noteKeywords = ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING'];
 
 export default {
-  branches: ["main", "next", { name: "beta", prerelease: true }, { name: "alpha", prerelease: true }],
-  preset: "conventionalcommits",
+  branches: [
+    'main',
+    'next',
+    { name: 'beta', prerelease: true },
+    { name: 'alpha', prerelease: true },
+  ],
+  preset: 'conventionalcommits',
   plugins: [
     [
-      "@semantic-release/commit-analyzer",
+      '@semantic-release/commit-analyzer',
       { parserOpts: { noteKeywords }, releaseRules: depReleaseRules },
     ],
     [
-      "@semantic-release/exec",
+      '@semantic-release/exec',
       {
         prepareCmd:
           "test ${branch.type} != release || sed -i '/^## \\[/h;x;/^[^]]*-/{x;d};x' CHANGELOG.md",
       },
     ],
     [
-      "@semantic-release/release-notes-generator",
+      '@semantic-release/release-notes-generator',
       {
         parserOpts: { noteKeywords },
-        writerOpts: { commitsSort: ["subject", "scope"] },
+        writerOpts: { commitsSort: ['subject', 'scope'] },
       },
     ],
     [
-      "@semantic-release/changelog",
+      '@semantic-release/changelog',
       {
         changelogTitle:
-          "# Changelog\n\nAll notable changes to this project will be documented in this file. See\n[Conventional Commits](https://conventionalcommits.org) for commit guidelines.",
+          '# Changelog\n\nAll notable changes to this project will be documented in this file. See\n[Conventional Commits](https://conventionalcommits.org) for commit guidelines.',
       },
     ],
-    ["@semantic-release/npm", { tarballDir: "dist" }],
+    ['@semantic-release/npm', { tarballDir: 'dist' }],
     [
-      "@semantic-release/exec",
+      '@semantic-release/exec',
       {
         prepareCmd:
-          "npx --yes @cyclonedx/cyclonedx-npm@4.2.1 --ignore-npm-errors --output-format JSON --output-file sbom.cdx.json",
+          'npx --yes @cyclonedx/cyclonedx-npm@4.2.1 --ignore-npm-errors --output-format JSON --output-file sbom.cdx.json',
       },
     ],
     [
-      "@semantic-release/github",
+      '@semantic-release/github',
       {
-        assets: [{ path: "sbom.cdx.json", label: "CycloneDX SBOM (sbom.cdx.json)" }],
+        assets: [
+          { path: 'sbom.cdx.json', label: 'CycloneDX SBOM (sbom.cdx.json)' },
+        ],
       },
     ],
     [
-      "@semantic-release/git",
-      { message: "ci(release): ${nextRelease.version}\n\n${nextRelease.notes}" },
+      '@semantic-release/git',
+      {
+        message: 'ci(release): ${nextRelease.version}\n\n${nextRelease.notes}',
+      },
     ],
   ],
 };


### PR DESCRIPTION
## Migrate shared CI to `jabrown93/ci`

Repoints this repo off the reusable workflows in `jabrown93/.github` onto the versioned CI library `jabrown93/ci`. Part of the CI split; mirrors the validated `homebridge-philips-hue-sync-box#446`.

`node-build`, `codeql`, and `stale` are now **composite actions**, so their caller jobs own `runs-on`, the matrix, and the schedule. `npm-release` stays a **job-level reusable workflow**.

| File | Before | After |
|---|---|---|
| build | `node-build.yml` reusable | `actions/node-build`, matrix `['22.x','24.x']` owned here (`fail-fast:false`) |
| codeql | `codeql.yml` reusable | `actions/codeql` (javascript-typescript default; same job permissions) |
| stale | `stale.yml` reusable | `actions/stale` (schedule + permissions on the caller job) |
| release | `npm-release.yml@…#v1.5.0` | `npm-release.yml@63fdb13 # workflows-v1.0.0` (byte-identical file) |

### ⚠️ Behavior change to review
The `node-build` action runs **`npm run test`** — which the old reusable workflow did **not**. Because this repo was previously pinned at **v1.2.0**, it also now runs **`npm run prettier`** (v1.2.0's node-build ran neither prettier nor test). If `test`/`prettier` fail on this repo, that's a pre-existing gap the migration surfaces; the Build check on this PR is the gate.

All refs pinned to `jabrown93/ci@63fdb13`. `ci:` commit → no release bump. `dt-sbom.yml` is hand-inlined (not a consumer of the moved workflow) — untouched.
