### PR TITLE
fix(package): correct author URL and repository protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/jabrown93/homebridge-playstation.git"
+    "url": "git+https://github.com/jabrown93/homebridge-playstation.git"
   },
   "license": "ISC",
   "author": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": {
     "email": "npm@jaredbrown.io",
     "name": "Jared Brown",
-    "url": "https://github.com/jabrwn93"
+    "url": "https://github.com/jabrown93"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "config.schema.json"
   ],
   "scripts": {
-    "typecheck": "tsc --noEmit",
     "prettier": "prettier --check .",
     "format": "prettier --write .",
     "lint": "eslint src/**.ts",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     }
   ],
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
   "bin": {
     "homebridge-playstation-login": "dist/cli.js"
   },


### PR DESCRIPTION
## Summary
- Fixes `author.url` typo (`jabrwn93` → `jabrown93`)
- Replaces the deprecated `git://` repository URL with `git+https://` (GitHub dropped unauthenticated git:// support)
- Removes the duplicate `typecheck` script (identical to `tsc`)
- Declares `types` (dist/index.d.ts, safe: dev-config's shared tsconfig sets `declaration: true`)

Part of a fleet-wide package.json cleanup pass across the homebridge-* plugins.

## Test plan
- [x] `package.json` validated as well-formed JSON